### PR TITLE
chore: use Node 10, fix pkg name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "snyk2Spdx",
-  "description": "convert the snyk ouput to spdx format output",
+  "name": "snyk2spdx",
+  "description": "Convert the Snyk CLI ouput to SPDX format output",
   "main": "dist/index.js",
   "scripts": {
     "format:check": "prettier --check '{''{lib,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
@@ -25,7 +25,7 @@
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=10"
   },
   "files": [
     "bin",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
- same case package name & repo to avoid mixed case
- Engines must be Node 10 for CLI support
