### PR TITLE
chore: make linting pick up all files in src

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
         steps:
             - checkout
             - run: npm install
+            - run: npm lint
             - run: npm test
             - snyk/scan:
                 fail-on-issues: true

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Convert the Snyk CLI ouput to SPDX format output",
   "main": "dist/index.js",
   "scripts": {
-    "format:check": "prettier --check '{''{lib,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
-    "format": "prettier --write '{''{lib,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
+    "format:check": "prettier --check '{''{src,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
+    "format": "prettier --write '{''{src,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
     "lint": "npm run format:check && npm run lint:eslint",
-    "lint:eslint": "eslint --cache '{lib,test}/**/*.ts'",
+    "lint:eslint": "eslint --cache '{src,test}/**/*.ts'",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest",
     "test:coverage": "npm run test:unit -- --coverage",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
- run lint on test
- ensure all `src` files are covered