### PR TITLE
feat: basic document SPDX format

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,11 +1,21 @@
 import 'source-map-support/register';
-import { SPDXv3 } from '../types';
+import { SnykIssue, SnykTestOutput, SPDXv3, Profile } from '../types';
 import { convertSnykIssueToSpdx } from './convert-issue-to-spdx';
 
-export function convertSnykTestOutputToSPDX(data: any): SPDXv3 {
+export function convertSnykTestOutputToSPDX(data: SnykTestOutput): SPDXv3 {
   return {
-    vulnerabilities: data.vulnerabilities.map((i: any) =>
+    id: `SPDXRef-${data.projectName}`,
+    name: data.projectName,
+    specVersion: '3.0-alpha',
+    profile: [Profile.BASE, Profile.VULNERABILITIES],
+    dataLicense: 'TODO',
+    creator: 'Organization: Snyk Ltd',
+    documentNamespace: 'TODO',
+    comment: 'TODO',
+    description: `Snyk test result for project ${data.projectName} in SPDX SBOM format`,
+    created: Date.now().toString(),
+    vulnerabilities: data.vulnerabilities.map((i: SnykIssue) =>
       convertSnykIssueToSpdx(i),
     ),
-  } as SPDXv3;
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,79 @@
 export interface SPDXv3 {
+  id: string; //  e.g SPDXRef-document-name
+  name: string;
+  specVersion: string; // SPDX-2.2 | SPDX-3.0
+  profile: Profile[]; // TODO: ?? where is this from
+  // YYYY-MM-DDThh:mm:ssZ
+  created: string;
+  documentNamespace: string; // Url to the doc http://[CreatorWebsite]/[pathToSpdx]/[DocumentName]-[UUID]
+  // License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+  dataLicense: string;
+  // Single line of text with the following keywords:
+  // "Person: person name" and optional "(email)"
+  // "Organization: organization" and optional "(email)"
+  // "Tool: toolidentifier-version"
+  creator: string;
+  comment: string;
+  description: string;
   vulnerabilities: unknown;
 }
 
+export enum Profile {
+  'BASE' = 'base',
+  'VULNERABILITIES' = 'vulnerabilities',
+}
 
+export interface SnykTestOutput {
+  projectName: string;
+  vulnerabilities: SnykIssue[];
+  displayTargetFile?: string;
+  path: string;
+  remediation?: RemediationChanges;
+}
+
+export interface RemediationChanges {
+  unresolved: SnykIssue[];
+  upgrade: DependencyUpdates;
+  patch: {
+    [name: string]: PatchRemediation;
+  };
+  ignore: unknown;
+  pin: DependencyPins;
+}
+
+export interface Upgrade {
+  upgradeTo: string; // name@version
+}
+
+export interface UpgradeVulns extends Upgrade {
+  vulns: string[];
+}
+
+export interface UpgradeRemediation extends UpgradeVulns {
+  upgrades: string[];
+}
+
+export interface PatchRemediation {
+  paths: PatchObject[];
+}
+
+export interface PatchObject {
+  [name: string]: {
+    patched: string;
+  };
+}
+
+export interface DependencyUpdates {
+  [from: string]: UpgradeRemediation;
+}
+
+export interface DependencyPins {
+  [name: string]: PinRemediation;
+}
+
+export interface PinRemediation extends UpgradeVulns {
+  isTransitive: boolean;
+}
 // TODO: add more as needed
 // add only fields needed for conversion
 export interface SnykIssue {

--- a/test/lib/index.spec.ts
+++ b/test/lib/index.spec.ts
@@ -2,37 +2,34 @@ import { readFileSync } from 'fs';
 import * as pathLib from 'path';
 
 import { convertSnykTestOutputToSPDX } from '../../src';
+import { SnykTestOutput } from '../../src/types';
 
-function loadJson(filename: string): JSON {
+function loadJson<JsonFormat>(filename: string): JsonFormat {
   return JSON.parse(readFileSync(filename, 'utf-8'));
 }
 describe('convertSnykTestOutputToSPDX', () => {
   it('No Snyk vulnerabilities converted to SPDX v3 correctly', async () => {
-    const snykTestData = loadJson(
+    const snykTestData = loadJson<SnykTestOutput>(
       pathLib.resolve(__dirname, '../', 'fixtures/no-deps.json'),
     );
     const res = convertSnykTestOutputToSPDX(snykTestData);
-    // TODO: uncomment once working & update
-    // expect(res).toMatch({
-    //   id: 'TODOSPDXRef-no-prod-deps',
-    //   name: 'no-prod-deps',
-    //   specVersion: 'SPDX-3.0',
-    //   // TODO: profile: Profile[];
-    //   created: expect.any(String),
-    //   documentNamespace:
-    //     'http://[CreatorWebsite]/[pathToSpdx]/[DocumentName]-[UUID]',
-    //   // License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
-    //   dataLicense: 'TODO',
-    //   creator: 'Organization: Snyk Ltd',
-    //   comment: 'TODO',
-    //   description: 'TODO',
-    //   vulnerabilities: [],
-    // });
-
-    expect(res.vulnerabilities as any).toEqual([]);
+    expect(res).toMatchObject({
+      id: 'SPDXRef-no-prod-deps',
+      name: 'no-prod-deps',
+      specVersion: '3.0-alpha',
+      profile: ['base', 'vulnerabilities'],
+      created: expect.any(String),
+      documentNamespace: 'TODO',
+      dataLicense: 'TODO',
+      creator: 'Organization: Snyk Ltd',
+      comment: 'TODO',
+      description:
+        'Snyk test result for project no-prod-deps in SPDX SBOM format',
+      vulnerabilities: [],
+    });
   });
   it('Snyk issue is converted to SPDX v3 vulnerability', () => {
-    const snykTestData = loadJson(
+    const snykTestData = loadJson<SnykTestOutput>(
       pathLib.resolve(__dirname, '../', 'fixtures/ruby-vulnerabilities.json'),
     );
     const res = convertSnykTestOutputToSPDX(snykTestData);
@@ -51,7 +48,7 @@ describe('convertSnykTestOutputToSPDX', () => {
     );
   });
   it('license issues are not converted to vulnerabilities', () => {
-    const snykTestData = loadJson(
+    const snykTestData = loadJson<SnykTestOutput>(
       pathLib.resolve(__dirname, '../', 'fixtures/with-license-issues.json'),
     );
     const res = convertSnykTestOutputToSPDX(snykTestData);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Converting snyk test output data to base document fields
required by SPDX format.
