### PR TITLE
feat: generate dataLicense field

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^25.1.0",
     "ts-node": "8.6.2",
     "tsc-watch": "^4.1.0",
-    "typescript": "^3.7.5"
+    "typescript": "^4.1"
   },
   "pkg": {
     "scripts": [

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,12 +6,11 @@ export function convertSnykTestOutputToSPDX(data: SnykTestOutput): SPDXv3 {
   return {
     id: `SPDXRef-${data.projectName}`,
     name: data.projectName,
-    specVersion: '3.0-alpha',
+    specVersion: 'SPDX-3.0',
     profile: [Profile.BASE, Profile.VULNERABILITIES],
-    dataLicense: 'TODO',
+    dataLicense: 'CC0-1.0',
     creator: 'Organization: Snyk Ltd',
-    documentNamespace: 'TODO',
-    comment: 'TODO',
+    documentNamespace: 'TODO', // TODO: maybe file path?
     description: `Snyk test result for project ${data.projectName} in SPDX SBOM format`,
     created: Date.now().toString(),
     vulnerabilities: data.vulnerabilities.map((i: SnykIssue) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export interface SPDXv3 {
   id: string; //  e.g SPDXRef-document-name
   name: string;
-  specVersion: string; // SPDX-2.2 | SPDX-3.0
+  specVersion: SPDXSpecVersion; // SPDX-2.2 | SPDX-3.0
   profile: Profile[]; // TODO: ?? where is this from
   // YYYY-MM-DDThh:mm:ssZ
   created: string;
@@ -13,10 +13,13 @@ export interface SPDXv3 {
   // "Organization: organization" and optional "(email)"
   // "Tool: toolidentifier-version"
   creator: string;
-  comment: string;
   description: string;
   vulnerabilities: unknown;
 }
+
+type SPDXSpecVersions = '3.0' | '2.2';
+type SPDXSpecVersion = `SPDX-${SPDXSpecVersions}`;
+
 
 export enum Profile {
   'BASE' = 'base',

--- a/test/lib/index.spec.ts
+++ b/test/lib/index.spec.ts
@@ -16,13 +16,12 @@ describe('convertSnykTestOutputToSPDX', () => {
     expect(res).toMatchObject({
       id: 'SPDXRef-no-prod-deps',
       name: 'no-prod-deps',
-      specVersion: '3.0-alpha',
+      specVersion: 'SPDX-3.0',
       profile: ['base', 'vulnerabilities'],
       created: expect.any(String),
       documentNamespace: 'TODO',
-      dataLicense: 'TODO',
+      dataLicense: 'CC0-1.0',
       creator: 'Organization: Snyk Ltd',
-      comment: 'TODO',
       description:
         'Snyk test result for project no-prod-deps in SPDX SBOM format',
       vulnerabilities: [],
@@ -32,7 +31,19 @@ describe('convertSnykTestOutputToSPDX', () => {
     const snykTestData = loadJson<SnykTestOutput>(
       pathLib.resolve(__dirname, '../', 'fixtures/ruby-vulnerabilities.json'),
     );
+    const projectName = 'ruby-app';
     const res = convertSnykTestOutputToSPDX(snykTestData);
+    expect(res).toMatchObject({
+      id: `SPDXRef-${projectName}`,
+      name: projectName,
+      specVersion: 'SPDX-3.0',
+      profile: ['base', 'vulnerabilities'],
+      created: expect.any(String),
+      documentNamespace: 'TODO',
+      dataLicense: 'CC0-1.0',
+      creator: 'Organization: Snyk Ltd',
+      description: `Snyk test result for project ${projectName} in SPDX SBOM format`,
+    });
     expect((res.vulnerabilities as any).sort()).toEqual(
       [
         {
@@ -48,10 +59,22 @@ describe('convertSnykTestOutputToSPDX', () => {
     );
   });
   it('license issues are not converted to vulnerabilities', () => {
+    const projectName = 'app-with-already-fixed';
     const snykTestData = loadJson<SnykTestOutput>(
       pathLib.resolve(__dirname, '../', 'fixtures/with-license-issues.json'),
     );
     const res = convertSnykTestOutputToSPDX(snykTestData);
+    expect(res).toMatchObject({
+      id: `SPDXRef-${projectName}`,
+      name: projectName,
+      specVersion: 'SPDX-3.0',
+      profile: ['base', 'vulnerabilities'],
+      created: expect.any(String),
+      documentNamespace: 'TODO',
+      dataLicense: 'CC0-1.0',
+      creator: 'Organization: Snyk Ltd',
+      description: `Snyk test result for project ${projectName} in SPDX SBOM format`,
+    });
     expect((res.vulnerabilities as any).sort()).toEqual(
       [
         {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Generate the `dataLicense` field and drop `comment`