### PR TITLE
fix: drop input timeout

### DIFF
--- a/src/lib/get-input-data.ts
+++ b/src/lib/get-input-data.ts
@@ -1,6 +1,5 @@
 export async function readInputFromStdin(): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    setTimeout(() => reject(new Error('No input detected')), 100);
     let jsonString = '';
     process.stdin.setEncoding('utf8');
     process.stdin.on('readable', () => {


### PR DESCRIPTION

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
`snyk test --json` may take a while to run, so having a timeout will end the snyk2spdx process early.
