### PR TITLE
fix: change orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    snyk: snyk/snyk@0.0.8
+    snyk: snyk/snyk@1.1.2
 jobs:
     build-test-monitor:
         docker:


### PR DESCRIPTION

- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Change the orb version used i the circle ci config file for nightly tests